### PR TITLE
Grass must grow

### DIFF
--- a/Simulation/lib/Animals.hpp
+++ b/Simulation/lib/Animals.hpp
@@ -111,7 +111,7 @@ private:
   AnimalState defineState(Board board);
   void runBehaviour(Board * board);
   // Different behaviours
-  void _hungryBehaviour(Board board);
+  void _hungryBehaviour(Board * board);
   void _hornyBehaviour(Board * board);
   void _scaredBehaviour(Board board);
 };

--- a/Simulation/lib/Board.hpp
+++ b/Simulation/lib/Board.hpp
@@ -24,8 +24,8 @@ public:
   //  ~Board() { free(landTiles); };
 
   void updateBoardTimestep();
-  LandType getTileTypeAt(std::size_t x, std::size_t y) { return landTiles[x * _size_x + y]; };
-  LandType getTileTypeAt(std::pair<int,int> location) { return landTiles[location.first * _size_x + location.second]; };
+  LandType getTileTypeAt(std::size_t x, std::size_t y) { return foodTiles[x * _size_x + y] ? LandType::Ground : landTiles[x * _size_x + y]; };
+  LandType getTileTypeAt(std::pair<int,int> location) { return foodTiles[location.first * _size_x + location.second] ? LandType::Ground : landTiles[location.first * _size_x + location.second]; };
   void printBoard();
   void populateLandTypes(LandType type, int nTiles);
   void addPond(int nTiles);
@@ -48,10 +48,13 @@ public:
   bool isAnimalRemovalBuffered(int id){return (std::find(_idsToDelete.begin(),_idsToDelete.end(),id) != _idsToDelete.end());};
   void removeFromMap(int id);
   Animal* getAnimalAt(std::pair<int,int> location) { return animalTiles[location.first * _size_x + location.second]; };
+  // Manipulate food tiles
+  void eatFoodAt(std::pair<int,int> location) { foodTiles[location.first * _size_x + location.second] = 1000; };
   std::vector<Animal*> getAnimals();
   std::map<int,Animal*>* getAnimalMap(){return &_animalMap;};
 private:
   std::vector<LandType> landTiles;
+  std::vector<size_t> foodTiles;
   std::vector<Animal*> animalTiles;
   int _size_x, _size_y;
   std::mt19937 rand_gen;

--- a/Simulation/src/Animals.cpp
+++ b/Simulation/src/Animals.cpp
@@ -194,7 +194,7 @@ Rabbit::Rabbit(
   this->_animal_print = "db";
   this->_movementIncrement = movementInc;
   this->_forbiddenLand = {LandType::Water};
-  this->_sightRange = 6;
+  this->_sightRange = 8;
   this->_animalName = "rabbit";
   for (int i = -_sightRange; i < _sightRange + 1; i++){
     for (int j = -_sightRange; j < _sightRange + 1; j++){
@@ -225,7 +225,7 @@ void Rabbit::runBehaviour(Board * board){
     this->_thirstyBehaviour(*board);
     break;
   case AnimalState::Hungry:
-    _hungryBehaviour(*board);
+    _hungryBehaviour(board);
     break;
   case AnimalState::Horny:
     _hornyBehaviour(board);
@@ -241,8 +241,8 @@ Animal::AnimalState Rabbit::defineState(Board board){
   
   // Rabbits hide too long if they only care about the predator
   // Adding a critical low threshold for hunger and thirst
-  if (_thirst > this->_thirstCritThreshold) return AnimalState::Thirsty;
   if (_energy < this->_energyCritThreshold) return AnimalState::Hungry;
+  if (_thirst > this->_thirstCritThreshold) return AnimalState::Thirsty;
   // Next thing is to worry about predators
   Animal * closestFox = findClosestAnimal(board, "fox");
   if (closestFox) return AnimalState::Scared;
@@ -271,17 +271,18 @@ void Rabbit::_scaredBehaviour(Board board){
   moveAnimal(moveLocation);
 } // Rabbit::_scaredBehaviour()
 
-void Rabbit::_hungryBehaviour(Board board){
-  std::pair<int,int> nearestFood = searchFor(board, LandType::Food);
+void Rabbit::_hungryBehaviour(Board * board){
+  std::pair<int,int> nearestFood = searchFor(* board, LandType::Food);
   if (nearestFood.first < 0){
-    moveOneRandom(board,this->_forbiddenLand);
+    moveOneRandom(*board,this->_forbiddenLand);
   }
   else{
-    std::pair<int,int> moveLocation = board.plotMoveTowards(_location,nearestFood,this->_forbiddenLand);
+    std::pair<int,int> moveLocation = board->plotMoveTowards(_location,nearestFood,this->_forbiddenLand);
     moveAnimal(moveLocation);
   }
-  if (board.adjacentContains(_location,{LandType::Food})){
+  if (board->adjacentContains(_location,{LandType::Food})){
     this->_energy = 1.;
+    board->eatFoodAt(nearestFood);
   }
 };
 

--- a/Simulation/src/Board.cpp
+++ b/Simulation/src/Board.cpp
@@ -9,6 +9,7 @@ Board::Board(size_t size_x, size_t size_y):
   for (int i = 0; i < _size_x * _size_y; i++){
     landTiles.push_back(LandType::Ground);
     animalTiles.push_back(NULL);
+    foodTiles.push_back(0);
   }
 
   // Initialise random generators
@@ -229,4 +230,9 @@ void Board::updateBoardTimestep(){
   // remove the buffered animals
   _removeBuffered();
   // plausibly this is also where we could change where food if we decide to do that
+  for (auto & foodTile: foodTiles){
+    if (foodTile > 0){
+      foodTile -= 1;
+    }
+  }
 }


### PR DESCRIPTION
Added in an additional board to the Board class that contains an int for each tile. If this is number is >0, it appears as `LandType::Ground` in the `getTileTypeAt` methods, and decrements every timestep.

This has the effect of simulating a resource taking time to replenish. For now this is just grass re-growing, but could potentially be used to simulate water or other resources coming back.

Also minor tweak to rabbit behaviour to make critical hunger more important than critical thirst.